### PR TITLE
New Design, 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,15 +160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,21 +301,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
@@ -414,12 +393,6 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "systemd-boot-friend-rs"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "argh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,15 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.43"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
 name = "argh"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7317a549bc17c5278d9e72bb6e62c6aa801ac2567048e39ebc1c194249323e"
+checksum = "91792f088f87cdc7a2cfb1d617fa5ea18d7f1dc22ef0e1b5f82f3157cdc522be"
 dependencies = [
  "argh_derive",
  "argh_shared",
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "argh_derive"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60949c42375351e9442e354434b0cba2ac402c1237edf673cac3a4bf983b8d3c"
+checksum = "c4eb0c0c120ad477412dc95a4ce31e38f2113e46bd13511253f79196ca68b067"
 dependencies = [
  "argh_shared",
  "heck",
@@ -33,15 +33,15 @@ dependencies = [
 
 [[package]]
 name = "argh_shared"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a61eb019cb8f415d162cb9f12130ee6bbe9168b7d953c17f4ad049e4051ca00"
+checksum = "781f336cc9826dbaddb9754cb5db61e64cab4f69668bd19dcc4a0394a86f4cb1"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "cfg-if"
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if",
  "libc",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -122,6 +122,12 @@ checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "itoap"
@@ -137,9 +143,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.100"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
+checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
 name = "linked-hash-map"
@@ -188,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -200,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -210,18 +216,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core",
 ]
@@ -237,18 +243,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "remove_dir_all"
@@ -322,18 +328,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.129"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f72836d2aa753853178eda473a3b9d8e4eefdaf20523b919677e6de489f8f1"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.129"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57ae87ad533d9a56427558b516d0adac283614e347abf85b0dc0cbbf0a249f3"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -341,10 +347,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.75"
+name = "serde_json"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -361,6 +378,7 @@ dependencies = [
  "sailfish",
  "semver",
  "serde",
+ "serde_json",
  "toml",
 ]
 
@@ -380,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
 dependencies = [
  "libc",
  "winapi",
@@ -405,9 +423,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"
@@ -417,9 +435,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "version_check"
@@ -466,6 +484,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,15 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.41"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "argh"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91792f088f87cdc7a2cfb1d617fa5ea18d7f1dc22ef0e1b5f82f3157cdc522be"
+checksum = "2e7317a549bc17c5278d9e72bb6e62c6aa801ac2567048e39ebc1c194249323e"
 dependencies = [
  "argh_derive",
  "argh_shared",
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "argh_derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4eb0c0c120ad477412dc95a4ce31e38f2113e46bd13511253f79196ca68b067"
+checksum = "60949c42375351e9442e354434b0cba2ac402c1237edf673cac3a4bf983b8d3c"
 dependencies = [
  "argh_shared",
  "heck",
@@ -33,15 +33,15 @@ dependencies = [
 
 [[package]]
 name = "argh_shared"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781f336cc9826dbaddb9754cb5db61e64cab4f69668bd19dcc4a0394a86f4cb1"
+checksum = "8a61eb019cb8f415d162cb9f12130ee6bbe9168b7d953c17f4ad049e4051ca00"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cfg-if"
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -122,12 +122,6 @@ checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "itoap"
@@ -143,9 +137,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
 
 [[package]]
 name = "linked-hash-map"
@@ -194,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -206,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -216,18 +210,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
 ]
@@ -243,18 +237,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.6"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.23"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -328,18 +322,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "d1f72836d2aa753853178eda473a3b9d8e4eefdaf20523b919677e6de489f8f1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "e57ae87ad533d9a56427558b516d0adac283614e347abf85b0dc0cbbf0a249f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -347,21 +341,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "syn"
-version = "1.0.69"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
+checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -378,7 +361,6 @@ dependencies = [
  "sailfish",
  "semver",
  "serde",
- "serde_json",
  "toml",
 ]
 
@@ -398,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
@@ -423,9 +405,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
@@ -435,9 +417,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "version_check"
@@ -484,6 +466,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "filetime"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,10 +115,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "itoap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9028f49264629065d057f340a86acb84867925865f73bbf8d47b4d149a7e88b8"
 
 [[package]]
 name = "lazy_static"
@@ -119,6 +146,18 @@ name = "libc"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "pest"
@@ -195,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.6"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -231,6 +270,43 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "sailfish"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816920a08514d9741242b3efe70c16c350ed548bc4a5ba03426e56faf9d45f77"
+dependencies = [
+ "itoap",
+ "ryu",
+ "sailfish-macros",
+ "version_check",
+]
+
+[[package]]
+name = "sailfish-compiler"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4276e7b848bde8e7813d534f014bc35ce5acd2b9e2b6b075727113fcf478ba63"
+dependencies = [
+ "filetime",
+ "home",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "yaml-rust",
+]
+
+[[package]]
+name = "sailfish-macros"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bba2458ef07ae12c9aed2edb866c3db2f9c21cf19a2c3f2613b2982bc1a4a46"
+dependencies = [
+ "proc-macro2",
+ "sailfish-compiler",
+]
 
 [[package]]
 name = "semver"
@@ -299,6 +375,7 @@ dependencies = [
  "anyhow",
  "argh",
  "dialoguer",
+ "sailfish",
  "semver",
  "serde",
  "serde_json",
@@ -363,6 +440,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
 name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +472,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +227,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
 name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +271,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +301,7 @@ dependencies = [
  "dialoguer",
  "semver",
  "serde",
+ "serde_json",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systemd-boot-friend-rs"
-version = "0.7.2"
+version = "0.8.0"
 authors = ["Jack Wu <origincode@aosc.io>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0"
 argh = "0.1"
 dialoguer = "0.8"
 semver = "0.11"
+sailfish = "0.3"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 toml = "0.5"
 anyhow = "1.0"
 argh = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "systemd-boot-friend-rs"
 version = "0.8.0"
-authors = ["Jack Wu <origincode@aosc.io>"]
+authors = ["Kaiyang Wu <origincode@aosc.io>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 toml = "0.5"
 anyhow = "1.0"
 argh = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ toml = "0.5"
 anyhow = "1.0"
 argh = "0.1"
 dialoguer = "0.8"
-semver = "0.11"
+semver = "1.0"
 sailfish = "0.3"
 
 [profile.release]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,6 @@ pub struct Interface {
 #[argh(subcommand)]
 pub enum SubCommandEnum {
     Init(Init),
-    MakeConf(MakeConf),
     List(List),
     Install(Install),
 }
@@ -23,15 +22,6 @@ pub enum SubCommandEnum {
 #[argh(subcommand, name = "init")]
 /// Initialize systemd-boot-friend
 pub struct Init {}
-
-#[derive(FromArgs, Debug)]
-#[argh(subcommand, name = "mkconf")]
-/// Create systemd-boot entry config
-pub struct MakeConf {
-    /// force overwrite the entry config or not
-    #[argh(switch, short = 'f')]
-    pub force: bool,
-}
 
 #[derive(FromArgs, Debug)]
 #[argh(subcommand, name = "list")]
@@ -44,4 +34,7 @@ pub struct List {}
 pub struct Install {
     #[argh(positional)]
     pub target: Option<String>,
+    /// force overwrite the entry config or not
+    #[argh(switch, short = 'f')]
+    pub force: bool,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,8 @@ pub enum SubCommandEnum {
     Init(Init),
     List(List),
     Install(Install),
+    ListInstalled(ListInstalled),
+    Remove(Remove),
 }
 
 #[derive(FromArgs, Debug)]
@@ -37,4 +39,17 @@ pub struct Install {
     /// force overwrite the entry config or not
     #[argh(switch, short = 'f')]
     pub force: bool,
+}
+
+#[derive(FromArgs, Debug)]
+#[argh(subcommand, name = "list-installed")]
+/// List all installed kernels
+pub struct ListInstalled {}
+
+#[derive(FromArgs, Debug)]
+#[argh(subcommand, name = "remove")]
+/// Remove the kernel specified
+pub struct Remove {
+    #[argh(positional)]
+    pub target: Option<String>,
 }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -11,7 +11,7 @@ const MODULES_PATH: &str = "/usr/lib/modules/";
 const REL_ENTRY_PATH: &str = "loader/entries/";
 
 /// A kernel struct for parsing kernel filenames
-#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct Kernel {
     pub version: Version,
     pub localversion: String,

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -14,13 +14,13 @@ const REL_ENTRY_PATH: &str = "loader/entries/";
 
 #[derive(TemplateOnce)]
 #[template(path = "entry.stpl")]
-struct Entry {
-    distro: String,
-    kernel: String,
-    vmlinuz: String,
-    ucode: Option<String>,
-    initrd: String,
-    options: String,
+struct Entry<'a> {
+    distro: &'a str,
+    kernel: &'a str,
+    vmlinuz: &'a str,
+    ucode: Option<&'a str>,
+    initrd: &'a str,
+    options: &'a str,
 }
 
 /// A kernel struct for parsing kernel filenames
@@ -54,7 +54,7 @@ impl FromStr for Kernel {
     type Err = anyhow::Error;
 
     fn from_str(text: &str) -> Result<Self> {
-        // Split the kernel filename into 3 parts in order to determine
+        // Split the kernel filename into 2 parts in order to determine
         // the version and the localversion of the kernel
         let mut splitted_kernel_name = text.splitn(2, '-');
         let version = Version::parse(
@@ -194,21 +194,21 @@ impl Kernel {
         fs::write(
             entry_path,
             Entry {
-                distro: config.distro.to_owned(),
-                kernel: self.to_string(),
-                vmlinuz: self.vmlinuz.to_owned(),
+                distro: &config.distro,
+                kernel: &self.to_string(),
+                vmlinuz: &self.vmlinuz,
                 ucode: if config
                     .esp_mountpoint
                     .join(REL_DEST_PATH)
                     .join(UCODE)
                     .exists()
                 {
-                    Some(UCODE.to_owned())
+                    Some(UCODE)
                 } else {
                     None
                 },
-                initrd: self.initrd.to_owned(),
-                options: config.bootarg.to_owned(),
+                initrd: &self.initrd,
+                options: &config.bootarg,
             }
             .render_once()?,
         )?;

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1,5 +1,6 @@
 use crate::{println_with_prefix, CONF_PATH, REL_DEST_PATH};
 use anyhow::{anyhow, Result};
+use core::{default::Default, str::FromStr};
 use dialoguer::{theme::ColorfulTheme, Confirm};
 use semver::Version;
 use std::{fmt, fs, path::Path};
@@ -33,21 +34,13 @@ impl fmt::Display for Kernel {
     }
 }
 
-impl Default for Kernel {
-    fn default() -> Self {
-        Self {
-            version: Version::new(0, 0, 0),
-            localversion: "unknown".to_owned(),
-        }
-    }
-}
+impl FromStr for Kernel {
+    type Err = anyhow::Error;
 
-impl Kernel {
-    /// Parse a kernel filename
-    pub fn parse(kernel_name: &str) -> Result<Self> {
+    fn from_str(text: &str) -> Result<Self> {
         // Split the kernel filename into 3 parts in order to determine
         // the version, name and the flavor of the kernel
-        let mut splitted_kernel_name = kernel_name.splitn(2, '-');
+        let mut splitted_kernel_name = text.splitn(2, '-');
         let version = Version::parse(
             splitted_kernel_name
                 .next()
@@ -61,6 +54,22 @@ impl Kernel {
             version,
             localversion,
         })
+    }
+}
+
+impl Default for Kernel {
+    fn default() -> Self {
+        Self {
+            version: Version::new(0, 0, 0),
+            localversion: "unknown".to_owned(),
+        }
+    }
+}
+
+impl Kernel {
+    /// Parse a kernel filename
+    pub fn parse(kernel_name: &str) -> Result<Self> {
+        Self::from_str(kernel_name)
     }
 
     /// Generate a sorted vector of kernel filenames
@@ -198,5 +207,8 @@ fn test_kernel_struct() {
 
 #[test]
 fn test_kernel_display() {
-    assert_eq!(format!("{}", Kernel::parse("0.0.0-unknown").unwrap()), "0.0.0-unknown")
+    assert_eq!(
+        format!("{}", Kernel::parse("0.0.0-unknown").unwrap()),
+        "0.0.0-unknown"
+    )
 }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -164,6 +164,7 @@ impl Kernel {
         Ok(())
     }
 
+    // Try to remove a kernel
     pub fn remove(&self, esp_path: &Path) -> Result<()> {
         let kernel_path = esp_path.join(REL_DEST_PATH);
         println_with_prefix!("Removing {} kernel ...", self);

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -75,10 +75,6 @@ impl Kernel {
                 )
             })
             .collect::<Result<Vec<Self>>>()?;
-        // make sure the vector is not empty
-        if kernels.is_empty() {
-            return Err(anyhow!("No kernel found"));
-        }
         // Sort the vector, thus the kernel filenames are
         // arranged with versions from newer to older
         kernels.sort_by(|a, b| b.cmp(a));

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -185,7 +185,7 @@ impl Kernel {
             entry_path.display()
         );
         // Generate entry config
-        let title = format!("title {} {}\n", distro, self.localversion);
+        let title = format!("title {} ({})\n", distro, self.get_name());
         let vmlinuz = format!(
             "linux /{}vmlinuz-{}-{}\n",
             REL_INST_PATH, self.version, self.localversion

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -235,10 +235,9 @@ fn test_kernel_struct() {
 #[test]
 fn test_kernel_display() {
     assert_eq!(
-        format!(
-            "{}",
-            Kernel::parse("0.0.0-unknown", &Config::default()).unwrap()
-        ),
+        Kernel::parse("0.0.0-unknown", &Config::default())
+            .unwrap()
+            .to_string(),
         "0.0.0-unknown"
     )
 }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -117,27 +117,17 @@ impl Kernel {
         let src_ucode = Path::new(UCODE_PATH);
         // Copy the source files to the `install_path` using specific
         // filename format, remove the version parts of the files
-        unwrap_or_show_error!(
-            {
-                fs::copy(
-                    &src_vmlinuz,
-                    install_path.join(format!("vmlinuz-{}-{}", self.version, self.localversion)),
-                )
-            },
-            "Unable to copy kernel file"
-        );
-        unwrap_or_show_error!(
-            {
-                fs::copy(
-                    &src_initramfs,
-                    install_path.join(format!(
-                        "initramfs-{}-{}.img",
-                        self.version, self.localversion
-                    )),
-                )
-            },
-            "Unable to copy initramfs file"
-        );
+        fs::copy(
+            &src_vmlinuz,
+            install_path.join(format!("vmlinuz-{}-{}", self.version, self.localversion)),
+        )?;
+        fs::copy(
+            &src_initramfs,
+            install_path.join(format!(
+                "initramfs-{}-{}.img",
+                self.version, self.localversion
+            )),
+        )?;
 
         // copy Intel ucode if exists
         if src_ucode.exists() {
@@ -191,14 +181,15 @@ impl Kernel {
             REL_INST_PATH, self.version, self.localversion
         );
         // automatically detect Intel ucode and write the config
-        let mut ucode = String::new();
-        if esp_path
+        let ucode = if esp_path
             .join(REL_INST_PATH)
             .join("intel-ucode.img")
             .exists()
         {
-            ucode = format!("initrd /{}intel-ucode.img\n", REL_INST_PATH);
-        }
+            format!("initrd /{}intel-ucode.img\n", REL_INST_PATH)
+        } else {
+            String::new()
+        };
         let initramfs = format!(
             "initrd /{}initramfs-{}-{}.img\n",
             REL_INST_PATH, self.version, self.localversion

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,14 +5,3 @@ macro_rules! println_with_prefix {
         eprintln!($($arg)+);
     };
 }
-
-#[macro_export]
-macro_rules! unwrap_or_show_error {
-    ($f:block, $e:expr) => {
-        let tmp = { $f };
-        if let Err(_) = tmp {
-            return Err(anyhow!("{}", $e));
-        }
-        tmp.unwrap()
-    };
-}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -7,17 +7,6 @@ macro_rules! println_with_prefix {
 }
 
 #[macro_export]
-macro_rules! yield_into {
-    (($x:ident) = $v:expr, $e:expr, $f:ident) => {
-        $x = $v.next().ok_or_else(|| anyhow!("{}: {}", $e, $f))?;
-    };
-    (($x:ident, $($y:ident),+) = $v:expr, $e:expr, $f:ident) => {
-        $x = $v.next().ok_or_else(|| anyhow!("{}: {}", $e, $f))?;
-        yield_into!(($($y),+) = $v, $e, $f);
-    }
-}
-
-#[macro_export]
 macro_rules! unwrap_or_show_error {
     ($f:block, $e:expr) => {
         let tmp = { $f };
@@ -25,5 +14,5 @@ macro_rules! unwrap_or_show_error {
             return Err(anyhow!("{}", $e));
         }
         tmp.unwrap()
-    }
+    };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,13 +33,13 @@ struct Config {
 }
 
 /// Choose a kernel using dialoguer
-fn choose_kernel(kernels: &Vec<Kernel>) -> Result<Kernel> {
+fn choose_kernel(kernels: &[Kernel]) -> Result<Kernel> {
     if kernels.is_empty() {
         return Err(anyhow!("Empty list"));
     }
     // build dialoguer Select for kernel selection
     let n = Select::with_theme(&ColorfulTheme::default())
-        .items(&kernels)
+        .items(kernels)
         .default(0)
         .interact()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,12 @@ fn init(config: &Config) -> Result<Kernel> {
 }
 
 fn main() -> Result<()> {
+    // CLI
+    let matches: Interface = from_env();
+    if matches.version {
+        println_with_prefix!(env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
     // Read config
     let config: Config = toml::from_slice(&fs::read(CONF_PATH)?)?;
     // the record file of installed kernels, use empty value if not found
@@ -99,12 +105,6 @@ fn main() -> Result<()> {
         // Create the folder structure for the record of installed kernels
         fs::create_dir_all(Path::new(INSTALLED_PATH).parent().unwrap())?;
         serde_json::to_writer(fs::File::create(INSTALLED_PATH)?, &Vec::<String>::new())?;
-    }
-    // CLI
-    let matches: Interface = from_env();
-    if matches.version {
-        println_with_prefix!(env!("CARGO_PKG_VERSION"));
-        return Ok(());
     }
     // Switch table
     match matches.nested {

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,8 +59,7 @@ fn init(distro: &str, esp_path: &Path, bootarg: &str) -> Result<()> {
     // choose the kernel to install and
     // write the entry config file
     let kernel = choose_kernel()?;
-    kernel.install(esp_path)?;
-    kernel.make_config(distro, esp_path, bootarg, false)?;
+    kernel.install_and_make_config(distro, esp_path, bootarg, false)?;
 
     Ok(())
 }
@@ -87,33 +86,23 @@ fn main() -> Result<()> {
                 }
             }
             SubCommandEnum::Install(args) => {
-                match args.target {
+                let kernel = match args.target {
                     // the target can be both the number in
                     // the list and the name of the kernel
-                    Some(n) => {
-                        let kernel = match n.parse::<usize>() {
-                            Ok(num) => Kernel::list_kernels()?[num - 1].clone(),
-                            Err(_) => Kernel::parse(&n)?,
-                        };
-                        kernel.install_and_make_config(
-                            &config.distro,
-                            &config.esp_mountpoint,
-                            &config.bootarg,
-                            args.force,
-                        )?;
-                    }
-                    // installs the newest kernel
+                    Some(n) => match n.parse::<usize>() {
+                        Ok(num) => Kernel::list_kernels()?[num - 1].clone(),
+                        Err(_) => Kernel::parse(&n)?,
+                    },
+                    // install the newest kernel
                     // when no target is given
-                    None => {
-                        let kernel = &Kernel::list_kernels()?[0];
-                        kernel.install_and_make_config(
-                            &config.distro,
-                            &config.esp_mountpoint,
-                            &config.bootarg,
-                            args.force,
-                        )?
-                    }
-                }
+                    None => Kernel::list_kernels()?[0].clone(),
+                };
+                kernel.install_and_make_config(
+                    &config.distro,
+                    &config.esp_mountpoint,
+                    &config.bootarg,
+                    args.force,
+                )?;
             }
         },
         None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,14 @@ use argh::from_env;
 use cli::{Interface, SubCommandEnum};
 use core::default::Default;
 use dialoguer::{theme::ColorfulTheme, Select};
-use kernel::Kernel;
 use serde::Deserialize;
 use std::{
     fs,
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
+
+use kernel::Kernel;
 
 mod cli;
 mod kernel;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ mod kernel;
 mod macros;
 
 const CONF_PATH: &str = "/etc/systemd-boot-friend.conf";
-const REL_INST_PATH: &str = "EFI/aosc/";
+const REL_DEST_PATH: &str = "EFI/aosc/";
 
 #[derive(Debug, Deserialize)]
 struct Config {
@@ -39,6 +39,19 @@ fn choose_kernel() -> Result<Kernel> {
     Ok(kernels[n].clone())
 }
 
+/// Choose an installed kernel using dialoguer
+fn choose_installed_kernel() -> Result<Kernel> {
+    // let kernels = Kernel::list_installed_kernels()?;
+    // // build dialoguer Select for kernel selection
+    // let n = Select::with_theme(&ColorfulTheme::default())
+    //     .items(&kernels)
+    //     .default(0)
+    //     .interact()?;
+    //
+    // Ok(kernels[n].clone())
+    todo!()
+}
+
 /// Initialize the default environment for friend
 fn init(distro: &str, esp_path: &Path, bootarg: &str) -> Result<()> {
     // use bootctl to install systemd-boot
@@ -55,7 +68,7 @@ fn init(distro: &str, esp_path: &Path, bootarg: &str) -> Result<()> {
         .spawn()?;
     // create folder structure
     println_with_prefix!("Creating folder structure for friend ...");
-    fs::create_dir_all(esp_path.join(REL_INST_PATH))?;
+    fs::create_dir_all(esp_path.join(REL_DEST_PATH))?;
     // choose the kernel to install and
     // write the entry config file
     let kernel = choose_kernel()?;
@@ -104,6 +117,8 @@ fn main() -> Result<()> {
                     args.force,
                 )?;
             }
+            SubCommandEnum::ListInstalled(_) => todo!(),
+            SubCommandEnum::Remove(args) => todo!(),
         },
         None => {
             let kernel = choose_kernel()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,8 @@ mod kernel;
 mod macros;
 
 const CONF_PATH: &str = "/etc/systemd-boot-friend.conf";
-const REL_DEST_PATH: &str = "EFI/aosc/";
+const REL_DEST_PATH: &str = "EFI/systemd-boot-friend/";
+const INSTALLED_PATH: &str = "/var/lib/systemd-boot-friend/installed.json";
 
 #[derive(Debug, Deserialize)]
 struct Config {
@@ -28,8 +29,7 @@ struct Config {
 }
 
 /// Choose a kernel using dialoguer
-fn choose_kernel() -> Result<Kernel> {
-    let kernels = Kernel::list_kernels()?;
+fn choose_kernel(kernels: &Vec<Kernel>) -> Result<Kernel> {
     // build dialoguer Select for kernel selection
     let n = Select::with_theme(&ColorfulTheme::default())
         .items(&kernels)
@@ -39,21 +39,8 @@ fn choose_kernel() -> Result<Kernel> {
     Ok(kernels[n].clone())
 }
 
-/// Choose an installed kernel using dialoguer
-fn choose_installed_kernel() -> Result<Kernel> {
-    // let kernels = Kernel::list_installed_kernels()?;
-    // // build dialoguer Select for kernel selection
-    // let n = Select::with_theme(&ColorfulTheme::default())
-    //     .items(&kernels)
-    //     .default(0)
-    //     .interact()?;
-    //
-    // Ok(kernels[n].clone())
-    todo!()
-}
-
 /// Initialize the default environment for friend
-fn init(distro: &str, esp_path: &Path, bootarg: &str) -> Result<()> {
+fn init(distro: &str, esp_path: &Path, bootarg: &str) -> Result<Kernel> {
     // use bootctl to install systemd-boot
     println_with_prefix!("Initializing systemd-boot ...");
     Command::new("bootctl")
@@ -71,15 +58,19 @@ fn init(distro: &str, esp_path: &Path, bootarg: &str) -> Result<()> {
     fs::create_dir_all(esp_path.join(REL_DEST_PATH))?;
     // choose the kernel to install and
     // write the entry config file
-    let kernel = choose_kernel()?;
+    let kernel = choose_kernel(&Kernel::list_kernels()?)?;
     kernel.install_and_make_config(distro, esp_path, bootarg, false)?;
 
-    Ok(())
+    Ok(kernel)
 }
 
 fn main() -> Result<()> {
     // Read config
     let config: Config = toml::from_slice(&fs::read(CONF_PATH)?)?;
+    let mut installed_kernels = serde_json::from_slice::<Vec<String>>(&fs::read(INSTALLED_PATH)?)?
+        .iter()
+        .map(|s| Kernel::parse(s))
+        .collect::<Result<Vec<Kernel>>>()?;
     // CLI
     let matches: Interface = from_env();
     if matches.version {
@@ -90,7 +81,11 @@ fn main() -> Result<()> {
     match matches.nested {
         Some(s) => match s {
             SubCommandEnum::Init(_) => {
-                init(&config.distro, &config.esp_mountpoint, &config.bootarg)?
+                installed_kernels.push(init(
+                    &config.distro,
+                    &config.esp_mountpoint,
+                    &config.bootarg,
+                )?);
             }
             SubCommandEnum::List(_) => {
                 // list available kernels
@@ -116,12 +111,31 @@ fn main() -> Result<()> {
                     &config.bootarg,
                     args.force,
                 )?;
+                installed_kernels.push(kernel);
             }
-            SubCommandEnum::ListInstalled(_) => todo!(),
-            SubCommandEnum::Remove(args) => todo!(),
+            SubCommandEnum::ListInstalled(_) => {
+                for (i, k) in installed_kernels.iter().enumerate() {
+                    println!("\u{001b}[1m[{}]\u{001b}[0m {}", i + 1, k);
+                }
+            }
+            SubCommandEnum::Remove(args) => {
+                let kernel = match args.target {
+                    // the target can be both the number in
+                    // the list and the name of the kernel
+                    Some(n) => match n.parse::<usize>() {
+                        Ok(num) => installed_kernels[num - 1].clone(),
+                        Err(_) => Kernel::parse(&n)?,
+                    },
+                    // select the kernel to remove
+                    // when no target is given
+                    None => choose_kernel(&installed_kernels)?,
+                };
+                kernel.remove(&config.esp_mountpoint)?;
+                installed_kernels.retain(|k| *k != kernel);
+            }
         },
         None => {
-            let kernel = choose_kernel()?;
+            let kernel = choose_kernel(&Kernel::list_kernels()?)?;
             // make sure the kernel selected is installed
             kernel.install_and_make_config(
                 &config.distro,
@@ -129,8 +143,15 @@ fn main() -> Result<()> {
                 &config.bootarg,
                 false,
             )?;
+            installed_kernels.push(kernel);
         }
     }
+    // Write the installed kernels file
+    installed_kernels.sort();
+    installed_kernels.dedup();
+    let installed_kernels: Vec<String> =
+        installed_kernels.iter().map(|k| format!("{}", k)).collect();
+    serde_json::to_writer(fs::File::create(INSTALLED_PATH)?, &installed_kernels)?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn main() -> Result<()> {
                     Some(n) => match n.parse::<usize>() {
                         Ok(num) => Kernel::list_kernels()?
                             .get(num - 1)
-                            .ok_or_else(|| anyhow!("No kernel found"))?
+                            .ok_or_else(|| anyhow!("Invalid kernel number"))?
                             .clone(),
                         Err(_) => Kernel::parse(&n)?,
                     },
@@ -132,7 +132,10 @@ fn main() -> Result<()> {
                     // the target can be both the number in
                     // the list and the name of the kernel
                     Some(n) => match n.parse::<usize>() {
-                        Ok(num) => installed_kernels[num - 1].clone(),
+                        Ok(num) => installed_kernels
+                            .get(num - 1)
+                            .ok_or_else(|| anyhow!("Invalid kernel number"))?
+                            .clone(),
                         Err(_) => Kernel::parse(&n)?,
                     },
                     // select the kernel to remove

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,9 @@ struct Config {
 
 /// Choose a kernel using dialoguer
 fn choose_kernel(kernels: &Vec<Kernel>) -> Result<Kernel> {
+    if kernels.is_empty() {
+        return Err(anyhow!("Empty list"));
+    }
     // build dialoguer Select for kernel selection
     let n = Select::with_theme(&ColorfulTheme::default())
         .items(&kernels)
@@ -98,12 +101,18 @@ fn main() -> Result<()> {
                     // the target can be both the number in
                     // the list and the name of the kernel
                     Some(n) => match n.parse::<usize>() {
-                        Ok(num) => Kernel::list_kernels()?[num - 1].clone(),
+                        Ok(num) => Kernel::list_kernels()?
+                            .get(num - 1)
+                            .ok_or_else(|| anyhow!("No kernel found"))?
+                            .clone(),
                         Err(_) => Kernel::parse(&n)?,
                     },
                     // install the newest kernel
                     // when no target is given
-                    None => Kernel::list_kernels()?[0].clone(),
+                    None => Kernel::list_kernels()?
+                        .first()
+                        .ok_or_else(|| anyhow!("No kernel found"))?
+                        .clone(),
                 };
                 kernel.install_and_make_config(
                     &config.distro,

--- a/templates/entry.stpl
+++ b/templates/entry.stpl
@@ -1,0 +1,5 @@
+title <%- distro %> (<%- kernel %>)
+linux /<%- REL_DEST_PATH %><%- vmlinuz %><% if let Some(u) = ucode { %>
+initrd /<%- REL_DEST_PATH %><%- u %><% } %>
+initrd /<%- REL_DEST_PATH %><%- initrd %>
+options <%- options %>


### PR DESCRIPTION
Now the program parse the kernel filenames into `"$VERSION-$LOCALVERSION"` pattern. This design should now adapt to more distributions other than AOSC OS (probably, ~~I'm considering making the pattern customizable~~ yes it's now customizable).

Also, it now supports multiple versions of the same `$LOCALVERSION`, and will automatically create the boot entry once a kernel is installed. The installed kernels will be recorded at `/var/lib/systemd-boot-friend/installed.json`, which is used for removing a kernel (`systemd-boot-friend remove`).

This version is incompatible with the previous one.